### PR TITLE
Don't send 200 after error has been sent

### DIFF
--- a/api/extract.js
+++ b/api/extract.js
@@ -12,24 +12,26 @@ module.exports = async (req, res) => {
   if (!req.body || !req.body.ids || !req.body.ids.created.length === 0) {
     return res.send(200)
   }
+
   const {created} = req.body.ids
   const docs = await client.fetch(`*[_type == "sanity.fileAsset" && mimeType == "application/pdf" && _id in $created]{_id, url}`, {created})
   if (!docs.length) {
     return res.send(200)
   }
+
   console.log(`getting pdf documents `, docs)
   const data = await Promise.all(docs.map(({_id, url}) => crawler(url).then(({text}) => ({_id, text}))))
-  const result = await data
-    .reduce(
-      (trans, doc) =>
-        trans
-          .patch(doc._id, patch =>
-            patch.setIfMissing({ text: '' }).set({ text: doc.text })
-          ),
-      client.transaction()
-    )
-    .commit()
-    .catch(() => res.send(500))
-  console.log('result', result)
-  res.send(200)
+
+  const trx = data.reduce(
+    (trans, doc) => trans.patch(doc._id, patch => patch.set({text: doc.text})),
+    client.transaction()
+  )
+
+  try {
+    const result = await trx.commit()
+    console.log('result', result)
+    res.send(200)
+  } catch (err) {
+    res.send(500)
+  }
 }


### PR DESCRIPTION
Currently, if PDF processing fails, a 500 is sent, but since the error is suppressed, it'll flow through and attempt to send a 200 as well. This PR makes it _either_ send a 200 or a 500.

I also took the liberty of removing what _believe_ to be an unnecessary `setIfMissing` patch (since we're just setting a string field).
